### PR TITLE
Extend `netlify.toml` with build command and publish dir

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -6,7 +6,3 @@ curl -L https://github.com/rust-lang/mdBook/releases/download/v0.4.7/mdbook-v0.4
 
 # publish directory
 publish = "book/"
-
-
-[[headers]]
-for = "/*"

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,5 +1,8 @@
 [build]
-command = "curl -L https://github.com/rust-lang/mdBook/releases/download/v0.4.7/mdbook-v0.4.7-x86_64-unknown-linux-gnu.tar.gz | tar xvz && ./mdbook build"
+command = """\
+curl -L https://github.com/rust-lang/mdBook/releases/download/v0.4.7/mdbook-v0.4.7-x86_64-unknown-linux-gnu.tar.gz | tar xvz \
+&& ./mdbook build \
+"""
 
 # publish directory
 publish = "book/"

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,2 +1,9 @@
+[build]
+command = "curl -L https://github.com/rust-lang/mdBook/releases/download/v0.4.7/mdbook-v0.4.7-x86_64-unknown-linux-gnu.tar.gz | tar xvz && ./mdbook build"
+
+# publish directory
+publish = "book/"
+
+
 [[headers]]
 for = "/*"


### PR DESCRIPTION
This PR moves some of the netlify configuration from the UI to `netlify.toml`, which makes it more visible and easier to edit (esp. build command).

**Todo**
- [ ] Remove config from UI after merging