### PR TITLE
Removed ;

### DIFF
--- a/src/sessions/user_input_advanced.md
+++ b/src/sessions/user_input_advanced.md
@@ -66,7 +66,7 @@ impl Unit {
             Unit::Celsius => {
                 // return temperature as it is
             },
-        };
+        }
     }
 }
 ```


### PR DESCRIPTION
The semicolumn returned a () instead of f32

fn convert_temperature(&self, temperature:f32)-> f32 {
-------------------                           ^^^ expected `f32`, found `()`