### PR TITLE
Add link to template code when starting e-paper chapter

### DIFF
--- a/src/sessions/hello_epaper.md
+++ b/src/sessions/hello_epaper.md
@@ -1,6 +1,6 @@
 # Hello, e-Paper Display!
 
-Before adding the e-Paper display to the sensor project, we'll try it out on its own. Start with a new file based on `hello_extended.rs`.
+Before adding the e-Paper display to the sensor project, we'll try it out on its own. Start with a new file based on [1_hello_extended.rs](https://github.com/knurling-rs/knurling-session-20q4/blob/main/code/src/bin/1_hello_extended.rs).
 
 # Wiring
 


### PR DESCRIPTION
Update to docs to link to sample file in repo (similar to other chapters) rather than just the file name, at the start of
chapter on using the e-ink display in the carbon sensor.