### PR TITLE
Add toolchain set on 1.60 and fix doc

### DIFF
--- a/code/rust-toolchain.toml
+++ b/code/rust-toolchain.toml
@@ -1,0 +1,4 @@
+[toolchain]
+channel = "1.60.0"
+components = [ "cargo", "rustfmt", "rustc" ]
+targets = [ "thumbv7em-none-eabihf" ]

--- a/src/sessions/installation.md
+++ b/src/sessions/installation.md
@@ -4,7 +4,7 @@
 
 ### Base Rust installation
 
-Go to [https://rustup.rs](https://rustup.rs/) and follow the instructions.
+Go to [https://rustup.rs](https://rustup.rs/) and follow the instructions. You should **usually** be good with the latest stables. The [`knurling app template`](https://github.com/knurling-rs/app-template) contains a `rust-toolchain.toml` file that will help Rust using the latest working version of the compiler.
 
 **Windows**: *Do* install the optional components of the [C++ build tools package](https://visualstudio.microsoft.com/visual-cpp-build-tools/). The installation size may take up to 2 GB of disk space.
 


### PR DESCRIPTION
The template does not work using the latest stable of the moment: 1.61.0
To prevent the reader hitting some problems, this PR add a mention to the doc and especially a `rust-toolchain.toml` file that will help pick the proper Rust version.