### PR TITLE
Fix formatting hints

### DIFF
--- a/src/sessions/internal_temp.md
+++ b/src/sessions/internal_temp.md
@@ -8,13 +8,13 @@ Before we start to work with an external sensor, where we would have to write a 
 
 ✅  Open the [nrf-hal-common 0.11.1](https://github.com/nrf-rs/nrf-hal/tree/v0.11.1/nrf-hal-common)
 
-✅  Open `/src/temp.rs`, the place where the communication with the boards temperature sensor is implemented. 
+✅  Open `/src/temp.rs`, the place where the communication with the boards temperature sensor is implemented.
 
 The integrated temperature is a struct: `pub struct Temp(TEMP)`. It needs to be public, so it can be called from the outside. `TEMP` is a type defined in the peripheral access crate (pac), it accesses the temperature sensor's register block.  In the `impl` block are all the methods that are defined for `Temp`.
 
 Methods are different from functions in that they are attached to objects. Let's look at them in detail:
 
-`pub fn new()` takes `TEMP` as argument and returns `Temp`. The method takes ownership of the temperature sensor's register block.  
+`pub fn new()` takes `TEMP` as argument and returns `Temp`. The method takes ownership of the temperature sensor's register block.
 
 
 ✅  In order to be able to use `Temp` in your code, you have to bring it into scope first. Add the following lines to your code:
@@ -27,35 +27,35 @@ use nrf52840_hal::{
 };
 ```
 
-✅  Take ownership of the temperature sensor's register block by calling the new method, using `board.TEMP` as argument. The variable needs to be mutable. 
+✅  Take ownership of the temperature sensor's register block by calling the new method, using `board.TEMP` as argument. The variable needs to be mutable.
 
  ```rust
  let mut temp = Temp::new(board.TEMP);
  ```
 
-Now that we have an instance of the temperature sensor, we can take a measurement. 
+Now that we have an instance of the temperature sensor, we can take a measurement.
 
-✅ Go back to [temp.rs](https://github.com/nrf-rs/nrf-hal/blob/v0.11.1/nrf-hal-common/src/temp.rs) in the HAL code. 
+✅ Go back to [temp.rs](https://github.com/nrf-rs/nrf-hal/blob/v0.11.1/nrf-hal-common/src/temp.rs) in the HAL code.
 
-`fn measure()` takes a mutable reference to `self` as an argument. `self` is the instance of the temperature sensor that was created with `fn new()`. The method will stop a measurement, if one has already been started, starts a new measurement and block the program until it has completed the measurement and then returns a fixed point number `I30F2`. The second option is starting a measurement with `fn start_measurement()` and reading the measurement with `fn read()` which works in a non-blocking way. A measurement is started or stopped by writing to the register. 
+`fn measure()` takes a mutable reference to `self` as an argument. `self` is the instance of the temperature sensor that was created with `fn new()`. The method will stop a measurement, if one has already been started, starts a new measurement and block the program until it has completed the measurement and then returns a fixed point number `I30F2`. The second option is starting a measurement with `fn start_measurement()` and reading the measurement with `fn read()` which works in a non-blocking way. A measurement is started or stopped by writing to the register.
 
-We'll stick with the blocking method `fn measure()` for now. 
+We'll stick with the blocking method `fn measure()` for now.
 
-✅  In your code, add a line that takes a measurement, and one that logs the temperature value. 
+✅  In your code, add a line that takes a measurement, and one that logs the temperature value.
 
 ```rust
 let temperature = temp.measure();
 defmt::info!("{:?}", temperature);
 ```
-The syntax reflects that methods are attached to objects: The argument `&mut self` refers to the object in front of the dot, and the parenthesis remain empty. 
+The syntax reflects that methods are attached to objects: The argument `&mut self` refers to the object in front of the dot, and the parenthesis remain empty.
 
-If you run the code now, you'll run into a compiler error, because `the trait defmt::Format is not implemented for I30F2`, the return type of `fn measure()`. 
+If you run the code now, you'll run into a compiler error, because `the trait defmt::Format is not implemented for I30F2`, the return type of `fn measure()`.
 
-✅ Add another method `to_num()` behind `fn measure()`. This method casts the fix point number into an `f32`. In order to be displayable, the type needs to be indicated in the format string. 
+✅ Add another method `to_num()` behind `fn measure()`. This method casts the fix point number into an `f32`. In order to be displayable, the type needs to be indicated in the format string.
 
 ```rust
 let temperature: f32 = temp.measure().to_num();
-defmt::info!("{:f32} °C", temperature);
+defmt::info!("{=f32} °C", temperature);
 ```
 
-✅ Initialize a loop that measures and displays the temperature every 60 seconds. 
+✅ Initialize a loop that measures and displays the temperature every 60 seconds.

--- a/src/sessions/start_measuring.md
+++ b/src/sessions/start_measuring.md
@@ -4,18 +4,18 @@
 
 Last week, [defmt v0.1.0 to crates.io][defmt-crates] was released on crates.io. We prepared a handy [guide] on migrating your project from the github version of defmt to the crates.io version. New projects based on the app-template will automatically use the crates.io version from now on.
 
-# Refactoring of older instructions: 
+# Refactoring of older instructions:
 
 **Please read the Chapter [Bringing it all together](bring-together.html) and Chapter [Hello Sensor](https://knurling-books.ferrous-systems.com/sessions/hello_sensor.html) and put your code into modules**
 
 
 ----
 
-After making sure, the communication is set up correctly by reading and logging the version number of the firmware, we'll start making measurements. 
+After making sure, the communication is set up correctly by reading and logging the version number of the firmware, we'll start making measurements.
 
 An example of this implementation can be found here: [11_scd_30_measure.rs](https://github.com/knurling-rs/knurling-session-20q4/blob/main/code/src/bin/11_scd_30_measure.rs).
 
-✅ Go to section 1.4.1 of the [Interface Description]. 
+✅ Go to section 1.4.1 of the [Interface Description].
 
 What are the message components we have to provide, so that continuous measuring is triggered?
 
@@ -32,16 +32,16 @@ What are the message components we have to provide, so that continuous measuring
 </details>
 
 
-This Message does not only contain a command, but also an argument which allows to set a value for ambient air pressure. 
+This Message does not only contain a command, but also an argument which allows to set a value for ambient air pressure.
 
 
 # The Role of Ambient Air Pressure
 
 Together with temperature, air pressure determines how many gas molecules can be found in a defined space. The number of molecules rises when pressure increases and falls when pressure decreases. The Sensor's output unit for CO<sub>2</sub> is ppm, parts per million, which means of one million particles (atoms or molecules) the air contains as a whole, a certain number are Carbon dioxide molecules.
 
-If a very accurate sensor reading is necessary, the value for ambient air pressure should come from another sensor. When building an air quality monitor for work and school rooms, hardcoding a value is sufficient. The standard air pressure at sea-level is 1013.25 mbar, check you local weather station for a value if you live on higher altitudes. 
+If a very accurate sensor reading is necessary, the value for ambient air pressure should come from another sensor. When building an air quality monitor for work and school rooms, hardcoding a value is sufficient. The standard air pressure at sea-level is 1013.25 mbar, check you local weather station for a value if you live on higher altitudes.
 
-For this tutorial we use the current value from Berlin, which is 1020 mbar. 
+For this tutorial we use the current value from Berlin, which is 1020 mbar.
 
 # Start Continuous Measurement
 
@@ -57,9 +57,9 @@ pub fn start_continuous_measurement(&mut self, pressure: u16) -> Result<(), Erro
 }
 ```
 
-Next, we fill in the argument into the command. The sensor communication works in big endian byte order. 
+Next, we fill in the argument into the command. The sensor communication works in big endian byte order.
 
-✅ Convert the `u16` value into big-endian bytes. Assign the values contained in the returned slice to their respective positions in the command. 
+✅ Convert the `u16` value into big-endian bytes. Assign the values contained in the returned slice to their respective positions in the command.
 
 ```rust
 let argument_bytes = &pressure.to_be_bytes();
@@ -84,7 +84,7 @@ crc_all = "0.2.0"
 use crc_all::Crc;
 ```
 ✅ Check the documentation of [crc_all]. What arguments does the instance method `Crc::<u8>::new()` require?
-Go to the [Interface Description] of the sensor, section 1.1.3 and check if you can fill in all the arguments. 
+Go to the [Interface Description] of the sensor, section 1.1.3 and check if you can fill in all the arguments.
 
 <details>
     <summary>Answer</summary>
@@ -100,7 +100,7 @@ Go to the [Interface Description] of the sensor, section 1.1.3 and check if you 
 </details>
 
 
-✅ Inside `pub fn start_continuous_measurement()`, instantiate a new crc byte, with your gathered information. The variable needs to be mutable. Update the crc byte with the pressure value and assign the byte to its position in the command array. Send the command to the sensor. 
+✅ Inside `pub fn start_continuous_measurement()`, instantiate a new crc byte, with your gathered information. The variable needs to be mutable. Update the crc byte with the pressure value and assign the byte to its position in the command array. Send the command to the sensor.
 
 ```rust
 let mut crc = Crc::<u8>::new(0x31, 8, 0xff, 0x00, false);
@@ -111,7 +111,7 @@ command[4] = crc.finish();
 self.0.write(DEFAULT_ADDRESS, &command)?;
 ```
 
-✅ Go to your program file. In `fn main()` set the ambient air pressure and start measuring! 
+✅ Go to your program file. In `fn main()` set the ambient air pressure and start measuring!
 
 ```rust
 // substitute 1020_u16 with your local value
@@ -128,9 +128,9 @@ loop {
 
 ✅ Run the program. you should see a blinking led.
 
-After powering up, the sensor takes about 2 seconds until data is ready to be read. Besides just providing values, the sensor is also able to provide the information, if data is ready yet or not. 
+After powering up, the sensor takes about 2 seconds until data is ready to be read. Besides just providing values, the sensor is also able to provide the information, if data is ready yet or not.
 
-✅ In `src/scd30/mod.rs`, implement the data_ready method. Check the interface description for the command and length of the read buffer. 
+✅ In `src/scd30/mod.rs`, implement the data_ready method. Check the interface description for the command and length of the read buffer.
 
 <details>
     <summary>Answer</summary>
@@ -146,7 +146,7 @@ After powering up, the sensor takes about 2 seconds until data is ready to be re
     Ok(u16::from_be_bytes([rd_buffer[0], rd_buffer[1]]) == 1)
     }
     ```
-   
+
 </details>
 
 
@@ -165,16 +165,16 @@ loop {
 
 ## Reading and Logging Sensor Data
 
-The sensor returns three values, one for Carbon dioxide concentration, one for temperature and one for humidity. In section 1.5 in the [Interface Description] find the number type the sensor uses for the data. 
+The sensor returns three values, one for Carbon dioxide concentration, one for temperature and one for humidity. In section 1.5 in the [Interface Description] find the number type the sensor uses for the data.
 
 <details>
     <summary>Answer</summary>
 
     The values the sensor returns are float numbers in big-endian format.
-    
+
 </details>
 
-✅ Go to `src/scd30/mod.rs`. Add a new `struct` definition, with a field for each value. 
+✅ Go to `src/scd30/mod.rs`. Add a new `struct` definition, with a field for each value.
 
 ```rust
 pub struct SensorData {
@@ -192,9 +192,9 @@ where
 {
     // ...
 }
- ```   
+ ```
 
-✅ Inside the `impl SCD30` block, add a new method: 
+✅ Inside the `impl SCD30` block, add a new method:
 
 ```rust
 pub fn read_measurement(&mut self) -> Result<SensorData, Error> {
@@ -203,7 +203,7 @@ pub fn read_measurement(&mut self) -> Result<SensorData, Error> {
 }
 ```
 
-* Check the [Interface Description] for the command and length of the read buffer. 
+* Check the [Interface Description] for the command and length of the read buffer.
 * Make an instance of `SensorData`.
 * Convert the relevant bytes into `f32` values. Check the std documentation for conversion of big endian bytes to f32.
 * return the data.
@@ -243,11 +243,11 @@ pub fn read_measurement(&mut self) -> Result<SensorData, Error> {
     Ok(data)
 }
 ```
-    
+
 </details>
 
 
-✅ In your program file, inside the blinking loop, call the method and add the values and their unit to the log. 
+✅ In your program file, inside the blinking loop, call the method and add the values and their unit to the log.
 
 ```rust
 loop {
@@ -258,9 +258,9 @@ loop {
     let humidity = result.humidity;
 
     defmt::info!("
-        CO2 {:f32} ppm 
-        Temperature {:f32} °C
-        Humidity {:f32} %
+        CO2 {=f32} ppm
+        Temperature {=f32} °C
+        Humidity {=f32} %
         ", co2, temp, humidity
     );
 
@@ -268,13 +268,13 @@ loop {
 }
 ```
 
-✅ Run the program, you should see the three values in the log output. 
+✅ Run the program, you should see the three values in the log output.
 
 
 ## Optional Challenges:
 
-* The factory calibration of the sensor is pretty good, but you can still read up on how to calibrate the sensor and implement the necessary methods. 
-* Implement the altitude compensation method and use it instead of pressure compensation. 
+* The factory calibration of the sensor is pretty good, but you can still read up on how to calibrate the sensor and implement the necessary methods.
+* Implement the altitude compensation method and use it instead of pressure compensation.
 * Calculate absolute humidity from the relative humidity value you get from the sensor.
 * Calculate the dew point.
 * Implement the remaining methods listed in the sensor's [Interface Description].
@@ -283,5 +283,5 @@ loop {
 [Interface Description]: https://www.sensirion.com/fileadmin/user_upload/customers/sensirion/Dokumente/9.5_CO2/Sensirion_CO2_Sensors_SCD30_Interface_Description.pdf
 
 [crc_all]: https://docs.rs/crc_all/0.2.0/crc_all/
-[guide]: https://defmt.ferrous-systems.com/migration.html  
+[guide]: https://defmt.ferrous-systems.com/migration.html
 [defmt-crates]: https://crates.io/crates/defmt


### PR DESCRIPTION
Formatting hints such as `defmt::info!("{:f32} °C", temperature);` do not compile (Rust 1.60.0).
This PR fixes those as `defmt::info!("{=f32} °C", temperature);`
